### PR TITLE
Allow event pass-through on modal body container

### DIFF
--- a/Modal.ios.js
+++ b/Modal.ios.js
@@ -57,6 +57,7 @@ var Modal = React.createClass({
     customShowHandler: PropTypes.func,
     customHideHandler: PropTypes.func,
     forceToFront: PropTypes.bool,
+    containerPointerEvents: PropTypes.string,
   },
 
   getDefaultProps(): any {
@@ -68,6 +69,7 @@ var Modal = React.createClass({
       backdropType: 'plain',
       backdropBlur: 'light',
       forceToFront: false,
+      containerPointerEvents: 'auto',
     };
   },
 
@@ -121,7 +123,7 @@ var Modal = React.createClass({
     return (
       <View>
         {this.renderCloseButton()}
-        <View style={styles.modal}>
+        <View style={styles.modal} pointerEvents={this.props.containerPointerEvents}>
           {React.Children.map(this.props.children, React.addons.cloneWithProps)}
         </View>
       </View>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Component accepts several self-descriptive properties:
 - **`hideCloseButton`** _(Bool)_
 - **`backdropType`** _(String)_ `plain`, `none`, or `blur`. Default is `plain`.
 - **`backdropBlur`** _(String)_ If `backdropType` is `blur`, this can be either `dark`, `light`, or `extra-light`. Default is `light`. (thanks @kureev for [react-native-blur](https://github.com/Kureev/react-native-blur)!) [Demo here](https://raw.githubusercontent.com/brentvatne/react-native-modal/master/demo-blur.png).
+- **`containerPointerEvents`** _(String)_ `box-none`, `none`, `box-only`, `auto`. Default is `auto`. Set to `box-none` to trigger the `onPressBackdrop` callback when the modal body is touched. [See pointerEvents](https://facebook.github.io/react-native/docs/view.html#pointerevents).
 - **`isVisible`** _(Bool)_
 - **`onClose`** _(Function)_
 - **`onPressBackdrop`** _(Function)_ - callback to be fired when the user taps on the backdrop


### PR DESCRIPTION
This adds the prop `containerPointerEvents` (string), which is used to set the `pointerEvents` property of the modal body container. The default is `auto`. Setting it to `box-none`, for example, allows event pass-through, which is useful when setting a custom style, with the modal body transparent.
