### PR TITLE
Fix options.reset handling

### DIFF
--- a/Transitions.js
+++ b/Transitions.js
@@ -39,11 +39,7 @@ var Transitions = Object.assign(Mixin, {
 
           // Option to reset the state value to the initial value
           if (options.reset) {
-            if (options.reset) {
-              this.state[property] = begin;
-            } else {
-              this.state[property] = options.reset;
-            }
+            this.state[property] = begin;
           }
 
           // Custom onEnd callback


### PR DESCRIPTION
First, I removed the obsolete if condition surrounding the if..else block.

Then, when options.reset is true, the expected behavior is to reset the
property value to the begin value, which works. But when options.reset is
false or undefined, the property value would be set to false or
undefined at the end of the animation, which is not the desired effect. I
fixed this to reflect the expected behavior.
